### PR TITLE
syntax/nim: add discardable pragma

### DIFF
--- a/syntax/nim.vim
+++ b/syntax/nim.vim
@@ -93,7 +93,7 @@ syntax keyword nimPragma contained emit importcpp importobjc codegendecl
 syntax keyword nimPragma contained injectstmt intdefine strdefine cdecl importc
 syntax keyword nimPragma contained exportc extern bycopy byref varargs union
 syntax keyword nimPragma contained packed dynlib threadvar gcsafe locks guard
-syntax keyword nimPragma contained inline borrow booldefine
+syntax keyword nimPragma contained inline borrow booldefine discardable
 
 syntax region nimPragmaList
       \ start=+{\.+ end=+\.\?}+


### PR DESCRIPTION
Per https://nim-lang.org/docs/manual.html#statements-and-expressions-discard-statement, Nim supports `{.discardable.}` pragma.