### PR TITLE
use foldlevel to not have everything folded by default when opening a file

### DIFF
--- a/ftplugin/nim.vim
+++ b/ftplugin/nim.vim
@@ -12,6 +12,7 @@ setlocal comments=:##,:#,s1:#[,e:]#,fb:-
 setlocal commentstring=#%s
 setlocal foldignore=
 setlocal foldmethod=indent
+setlocal foldlevel=99
 setlocal formatoptions-=t formatoptions+=croql
 setlocal include=^\\s*\\(from\\|import\\|include\\)
 setlocal suffixesadd=.nim


### PR DESCRIPTION
I know you marked this issue (#9) as a won't fix, but locally I added this local modification to your plugin to not have my code folded by default (AFAIK it doesn't affect ability to fold code) when I open a file. I find it useful because it's a bit tedious to unfold everything - then again it's a matter of preference I guess.



