### PR TITLE
Quote dirty file path

### DIFF
--- a/autoload/nim/suggest/manager.vim
+++ b/autoload/nim/suggest/manager.vim
@@ -203,7 +203,7 @@ function! s:instance_query(command, opts, ...) abort dict
     if dirtyFile =~ invalidChars
       throw 'suggest-manager-file-internal: unsupported character in path to dirty file'
     endif
-    let fileQuery .= ';' . dirtyFile
+    let fileQuery .= ';"' . dirtyFile . '"'
     call writefile(getbufline(a:opts.buffer, 1, '$'), dirtyFile, 'S')
   endif
   if has_key(a:opts, 'pos')


### PR DESCRIPTION
For some reason nimsuggest can't find the temporary file if it's not quoted on windows 11. I tested this patch with Nim 1.7.1.